### PR TITLE
DisallowPartial option in AssignTickets

### DIFF
--- a/api/backend.proto
+++ b/api/backend.proto
@@ -115,6 +115,9 @@ message AssignmentFailure {
 message AssignTicketsRequest {
   // Assignments is a list of assignment groups that contain assignment and the Tickets to which they should be applied.
   repeated AssignmentGroup assignments = 1;
+
+  // If set, all assignments will fail if at least one ticket is missing.
+  bool disallow_partial = 2;
 }
 
 message AssignTicketsResponse {

--- a/api/backend.swagger.json
+++ b/api/backend.swagger.json
@@ -229,6 +229,10 @@
             "$ref": "#/definitions/openmatchAssignmentGroup"
           },
           "description": "Assignments is a list of assignment groups that contain assignment and the Tickets to which they should be applied."
+        },
+        "disallow_partial": {
+          "type": "boolean",
+          "description": "If set, all assignments will fail if at least one ticket is missing."
         }
       }
     },

--- a/internal/statestore/ticket.go
+++ b/internal/statestore/ticket.go
@@ -36,7 +36,6 @@ const (
 
 // CreateTicket creates a new Ticket in the state storage. If the id already exists, it will be overwritten.
 func (rb *redisBackend) CreateTicket(ctx context.Context, ticket *pb.Ticket) error {
-
 	redisConn, err := rb.redisPool.GetContext(ctx)
 	if err != nil {
 		return status.Errorf(codes.Unavailable, "CreateTicket, id: %s, failed to connect to redis: %v", ticket.GetId(), err)
@@ -354,6 +353,11 @@ func (rb *redisBackend) UpdateAssignments(ctx context.Context, req *pb.AssignTic
 			tickets = append(tickets, t)
 		}
 	}
+
+	if req.DisallowPartial && len(resp.Failures) > 0 {
+		return resp, []*pb.Ticket{}, status.Errorf(codes.NotFound, "one or more tickets were not found and partial assignments are disallowed")
+	}
+
 	assignmentTimeout := getAssignedDeleteTimeout(rb.cfg) / time.Millisecond
 	err = redisConn.Send("MULTI")
 	if err != nil {

--- a/pkg/pb/backend.pb.go
+++ b/pkg/pb/backend.pb.go
@@ -555,9 +555,11 @@ func (x *AssignmentFailure) GetCause() AssignmentFailure_Cause {
 type AssignTicketsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Assignments is a list of assignment groups that contain assignment and the Tickets to which they should be applied.
-	Assignments   []*AssignmentGroup `protobuf:"bytes,1,rep,name=assignments,proto3" json:"assignments,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Assignments []*AssignmentGroup `protobuf:"bytes,1,rep,name=assignments,proto3" json:"assignments,omitempty"`
+	// If set, all assignments will fail if at least one ticket is missing.
+	DisallowPartial bool `protobuf:"varint,2,opt,name=disallow_partial,json=disallowPartial,proto3" json:"disallow_partial,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *AssignTicketsRequest) Reset() {
@@ -595,6 +597,13 @@ func (x *AssignTicketsRequest) GetAssignments() []*AssignmentGroup {
 		return x.Assignments
 	}
 	return nil
+}
+
+func (x *AssignTicketsRequest) GetDisallowPartial() bool {
+	if x != nil {
+		return x.DisallowPartial
+	}
+	return false
 }
 
 type AssignTicketsResponse struct {
@@ -676,9 +685,10 @@ const file_api_backend_proto_rawDesc = "" +
 	"\x05cause\x18\x02 \x01(\x0e2\".openmatch.AssignmentFailure.CauseR\x05cause\"*\n" +
 	"\x05Cause\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x14\n" +
-	"\x10TICKET_NOT_FOUND\x10\x01\"T\n" +
+	"\x10TICKET_NOT_FOUND\x10\x01\"\x7f\n" +
 	"\x14AssignTicketsRequest\x12<\n" +
-	"\vassignments\x18\x01 \x03(\v2\x1a.openmatch.AssignmentGroupR\vassignments\"Q\n" +
+	"\vassignments\x18\x01 \x03(\v2\x1a.openmatch.AssignmentGroupR\vassignments\x12)\n" +
+	"\x10disallow_partial\x18\x02 \x01(\bR\x0fdisallowPartial\"Q\n" +
 	"\x15AssignTicketsResponse\x128\n" +
 	"\bfailures\x18\x01 \x03(\v2\x1c.openmatch.AssignmentFailureR\bfailures2\xad\x04\n" +
 	"\x0eBackendService\x12~\n" +


### PR DESCRIPTION
In many cases, if one assignment fails we want all of them to fail instead of creating a partial match. This PR adds and option all_or_none to the AssignTickets request that, if set, avoids assigning any of the tickets if at least one is not found before starting the assignment.
